### PR TITLE
Do not process an unknown state updates

### DIFF
--- a/custom_components/elro_connects/device.py
+++ b/custom_components/elro_connects/device.py
@@ -16,7 +16,7 @@ from elro.device import (
 from elro.utils import update_state_data
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_NAME, CONF_HOST, CONF_PORT
+from homeassistant.const import ATTR_NAME, CONF_API_KEY, CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity import DeviceInfo, EntityDescription
@@ -80,7 +80,9 @@ class ElroConnectsK1(K1):
         self, hass: HomeAssistant, entry: ConfigEntry
     ) -> None:
         """Process updated settings."""
-        await self.async_configure(entry.data[CONF_HOST], entry.data[CONF_PORT])
+        await self.async_configure(
+            entry.data[CONF_HOST], entry.data[CONF_PORT], entry.data.get(CONF_API_KEY)
+        )
 
     @property
     def data(self) -> dict[int, dict]:

--- a/custom_components/elro_connects/manifest.json
+++ b/custom_components/elro_connects/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://github.com/jbouwh/ha-elro-connects",
   "issue_tracker": "https://github.com/jbouwh/ha-elro-connects/issues",
-  "requirements": ["lib-elro-connects==0.5.1"],
+  "requirements": ["lib-elro-connects==0.5.2"],
   "codeowners": ["@jbouwh"],
   "iot_class": "local_polling",
   "version": "0.2.0"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
 pre-commit
-lib-elro-connects==0.5.1
+lib-elro-connects==0.5.2
 homeassistant
 pytest-homeassistant-custom-component

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -26,6 +26,6 @@ fnvhash==0.1.0
 
 lru-dict==1.1.7
 
-lib-elro-connects==0.5.1
+lib-elro-connects==0.5.2
 
 pytest-homeassistant-custom-component

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -110,6 +110,6 @@ async def test_configure_platforms_dynamically(
     async_fire_time_changed(hass, time)
     await hass.async_block_till_done()
 
-    assert hass.states.get("siren.beganegrond").state == "unknown"
+    assert hass.states.get("siren.beganegrond").state == "off"
     assert hass.states.get("siren.eerste_etage") is not None
     assert hass.states.get("siren.zolder") is not None


### PR DESCRIPTION
When the Elro Connects K1 connector reports an unknown state, or no device at all, this should not have impact on the state in Home Assistant. This PR assures updates are only done if the state is not unknown.