### PR TITLE
Refactoring coordinator and discovery

### DIFF
--- a/custom_components/elro_connects/__init__.py
+++ b/custom_components/elro_connects/__init__.py
@@ -1,20 +1,14 @@
 """The Elro Connects integration."""
 from __future__ import annotations
 
-import copy
-from datetime import timedelta
 import logging
 
-from elro.api import K1
-from elro.device import ATTR_DEVICE_STATE, STATE_UNKNOWN
-
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import SERVICE_RELOAD, Platform
-from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntry
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DEFAULT_INTERVAL, DOMAIN
+from .const import DOMAIN
 from .device import ElroConnectsK1
 
 _LOGGER = logging.getLogger(__name__)
@@ -25,78 +19,16 @@ PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.SIREN]
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Elro Connects from a config entry."""
 
-    current_device_set: set | None = None
-
-    async def _async_update_data() -> dict[int, dict]:
-        """Update data via API."""
-        nonlocal current_device_set
-        # get state from coordinator cash in case the current state is unknown
-        coordinator_update: dict[int, dict] = copy.deepcopy(coordinator.data or {})
-        # set initial state to unknown
-        for device_id, state_base in coordinator_update.items():
-            state_base[ATTR_DEVICE_STATE] = STATE_UNKNOWN
-        try:
-            await elro_connects_api.async_update()
-            device_update = copy.deepcopy(elro_connects_api.data)
-            for device_id, device_data in device_update.items():
-                if ATTR_DEVICE_STATE not in device_data:
-                    # Unlink entry without device state
-                    continue
-                if device_id not in coordinator_update:
-                    # new device, or known state
-                    coordinator_update[device_id] = device_data
-                elif device_data[ATTR_DEVICE_STATE] == STATE_UNKNOWN:
-                    # do not process unknown state updates
-                    continue
-                else:
-                    # update full state
-                    coordinator_update[device_id] = device_data
-
-        except K1.K1ConnectionError as err:
-            raise UpdateFailed(err) from err
-        new_set = set(elro_connects_api.data.keys())
-        if current_device_set is None:
-            current_device_set = new_set
-        if new_set - current_device_set:
-            current_device_set = new_set
-            # New devices discovered, trigger a reload
-            await hass.services.async_call(
-                DOMAIN,
-                SERVICE_RELOAD,
-                {},
-                blocking=False,
-            )
-        return coordinator_update
-
-    async def async_reload(call: ServiceCall) -> None:
-        """Reload the integration."""
-        await async_unload_entry(hass, entry)
-        await async_setup_entry(hass, entry)
-
-    coordinator = DataUpdateCoordinator(
-        hass,
-        _LOGGER,
-        name=DOMAIN.title(),
-        update_method=_async_update_data,
-        update_interval=timedelta(seconds=DEFAULT_INTERVAL),
-    )
-    elro_connects_api = ElroConnectsK1(
-        coordinator,
-        entry,
-    )
-
-    await coordinator.async_config_entry_first_refresh()
+    elro_connects_api = ElroConnectsK1(hass, _LOGGER, entry)
 
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = elro_connects_api
 
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    await elro_connects_api.async_config_entry_first_refresh()
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     entry.async_on_unload(
         entry.add_update_listener(elro_connects_api.async_update_settings)
-    )
-    hass.helpers.service.async_register_admin_service(
-        DOMAIN, SERVICE_RELOAD, async_reload
     )
 
     return True
@@ -122,6 +54,10 @@ async def async_remove_config_entry_device(
     if not device_id_str:
         return False
     device_id = int(device_id_str)
-    if device_id in elro_connects_api.data:
+    # Do not remove if the device_id is in the connector_data
+    if (
+        elro_connects_api.connector_data
+        and device_id in elro_connects_api.connector_data
+    ):
         return False
     return True

--- a/custom_components/elro_connects/__init__.py
+++ b/custom_components/elro_connects/__init__.py
@@ -87,7 +87,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await coordinator.async_config_entry_first_refresh()
 
-    hass.data[DOMAIN] = {}
+    hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = elro_connects_api
 
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)

--- a/custom_components/elro_connects/const.py
+++ b/custom_components/elro_connects/const.py
@@ -6,3 +6,5 @@ DEFAULT_INTERVAL = 15
 DEFAULT_PORT = 1025
 
 CONF_CONNECTOR_ID = "connector_id"
+
+ELRO_CONNECTS_NEW_DEVICE = "elro_connnects_new_dev_{}"

--- a/custom_components/elro_connects/device.py
+++ b/custom_components/elro_connects/device.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import asyncio
+import copy
+from datetime import timedelta
 import logging
 from typing import Any
 
@@ -18,7 +20,9 @@ from elro.device import (
     ALARM_HEAT,
     ALARM_SMOKE,
     ALARM_WATER,
+    ATTR_DEVICE_STATE,
     ATTR_DEVICE_TYPE,
+    STATE_UNKNOWN,
 )
 from elro.utils import update_state_data
 
@@ -27,15 +31,15 @@ from homeassistant.const import ATTR_NAME, CONF_API_KEY, CONF_HOST, CONF_PORT
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import EVENT_DEVICE_REGISTRY_UPDATED
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.entity import DeviceInfo, EntityDescription
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
+    UpdateFailed,
 )
 
-from .const import CONF_CONNECTOR_ID, DOMAIN
-
-_LOGGER = logging.getLogger(__name__)
+from .const import CONF_CONNECTOR_ID, DEFAULT_INTERVAL, DOMAIN, ELRO_CONNECTS_NEW_DEVICE
 
 MAX_RETRIES = 3
 
@@ -48,28 +52,37 @@ DEVICE_MODELS = {
 }
 
 
-class ElroConnectsK1(K1):
-    """Communicate with the Elro Connects K1 adapter."""
+class ElroConnectsK1(DataUpdateCoordinator, K1):
+    """Communicate with the Elro Connects K1 adapter and update the coordinator."""
 
     def __init__(
         self,
-        coordinator: DataUpdateCoordinator,
+        hass: HomeAssistant,
+        logger: logging.Logger,
         entry: ConfigEntry,
     ) -> None:
         """Initialize the K1 connector."""
-        self._coordinator = coordinator
-        self.hass = coordinator.hass
+        self.hass = hass
         self._entry = entry
+        self._logger = logger
 
-        self._data: dict[int, dict] = {}
+        self._connector_data: dict[int, dict] = {}
         self._api_lock = asyncio.Lock()
         self._connector_id = entry.data[CONF_CONNECTOR_ID]
         self._retry_count = 0
 
-        self._device_registry_updated = coordinator.hass.bus.async_listen(
+        self._device_registry_updated = hass.bus.async_listen(
             EVENT_DEVICE_REGISTRY_UPDATED, self._async_device_updated
         )
 
+        DataUpdateCoordinator.__init__(
+            self,
+            hass,
+            logger,
+            name=self._connector_id,
+            update_method=self._async_update_data,
+            update_interval=timedelta(seconds=DEFAULT_INTERVAL),
+        )
         K1.__init__(
             self,
             entry.data[CONF_HOST],
@@ -77,6 +90,38 @@ class ElroConnectsK1(K1):
             entry.data[CONF_PORT],
             entry.data.get(CONF_API_KEY),
         )
+
+    async def _async_update_data(self) -> dict[int, dict]:
+        """Update coordinator data via API."""
+        # get state from coordinator cash in case the current state is unknown
+        coordinator_update: dict[int, dict] = copy.deepcopy(self.data or {})
+        new_devices = False
+        try:
+            await self._async_fetch_connector_data()
+            device_update = copy.deepcopy(self._connector_data)
+            for device_id, device_data in device_update.items():
+                if ATTR_DEVICE_STATE not in device_data:
+                    # No valid device state, do not update
+                    continue
+                if device_id not in coordinator_update:
+                    # new device discovered
+                    new_devices = True
+                    coordinator_update[device_id] = device_data
+                elif device_data[ATTR_DEVICE_STATE] == STATE_UNKNOWN:
+                    # do not process unknown state updates
+                    continue
+                else:
+                    # full state update to coordinator device data
+                    coordinator_update[device_id] = device_data
+
+        except K1.K1ConnectionError as err:
+            raise UpdateFailed(err) from err
+
+        if new_devices:
+            async_dispatcher_send(
+                self.hass, ELRO_CONNECTS_NEW_DEVICE.format(self._entry.entry_id)
+            )
+        return coordinator_update
 
     async def _async_device_updated(self, event: Event) -> None:
         """Propagate name changes though the connector."""
@@ -95,8 +140,8 @@ class ElroConnectsK1(K1):
             # Not a valid device name or not a related entry
             return
         device_id = int(device_id_str)
-        if device_id not in self.data:
-            # the device is not in the coordinator data hence we cannot update it
+        if not self.connector_data or device_id not in self.connector_data:
+            # the device is not in the connector data hence we cannot update it
             return False
 
         if device_entry.name != device_entry.name_by_user:
@@ -108,24 +153,23 @@ class ElroConnectsK1(K1):
                 else device_entry.name_by_user,
             )
 
-    async def async_update(self) -> None:
-        """Synchronize with the K1 connector."""
-
-        async def _async_update() -> None:
-            new_data: dict[int, dict] = {}
-            update_status = await self.async_process_command(GET_ALL_EQUIPMENT_STATUS)
-            new_data = update_status
-            update_names = await self.async_process_command(GET_DEVICE_NAMES)
-            update_state_data(new_data, update_names)
-            self._retry_count = 0
-            self._data = new_data
+    async def _async_fetch_connector_data(self) -> None:
+        """Fetch new update from the K1 connector."""
 
         try:
             async with self._api_lock:
-                await self.hass.async_add_job(_async_update())
+                new_data: dict[int, dict] = {}
+                update_status = await self.async_process_command(
+                    GET_ALL_EQUIPMENT_STATUS
+                )
+                new_data = update_status
+                update_names = await self.async_process_command(GET_DEVICE_NAMES)
+                update_state_data(new_data, update_names)
+                self._retry_count = 0
+                self._connector_data = new_data
         except K1.K1ConnectionError as err:
             self._retry_count += 1
-            if not self._data or self._retry_count >= MAX_RETRIES:
+            if not self._connector_data or self._retry_count >= MAX_RETRIES:
                 raise K1.K1ConnectionError(err) from err
 
     async def async_command(
@@ -135,35 +179,28 @@ class ElroConnectsK1(K1):
     ) -> dict[int, dict[str, Any]] | None:
         """Execute a synchronized command through the K1 connector."""
         async with self._api_lock:
-            return self.hass.async_add_job(self.async_process_command(command, **argv))
+            return await self.async_process_command(command, **argv)
 
     async def async_update_settings(
         self, hass: HomeAssistant, entry: ConfigEntry
     ) -> None:
         """Process updated settings."""
         async with self._api_lock:
-            hass.async_create_task(
-                self.async_configure(
-                    entry.data[CONF_HOST],
-                    entry.data[CONF_PORT],
-                    entry.data.get(CONF_API_KEY),
-                )
+            await self.async_configure(
+                entry.data[CONF_HOST],
+                entry.data[CONF_PORT],
+                entry.data.get(CONF_API_KEY),
             )
 
     @property
-    def data(self) -> dict[int, dict]:
+    def connector_data(self) -> dict[int, dict]:
         """Return the synced state."""
-        return self._data
+        return self._connector_data
 
     @property
     def connector_id(self) -> str:
         """Return the K1 connector ID."""
         return self._connector_id
-
-    @property
-    def coordinator(self) -> DataUpdateCoordinator:
-        """Return the data update coordinator."""
-        return self._coordinator
 
 
 class ElroConnectsEntity(CoordinatorEntity):
@@ -177,9 +214,10 @@ class ElroConnectsEntity(CoordinatorEntity):
         description: EntityDescription,
     ) -> None:
         """Initialize the Elro connects entity."""
-        super().__init__(elro_connects_api.coordinator)
+        super().__init__(elro_connects_api)
 
-        self.data: dict = elro_connects_api.coordinator.data[device_id]
+        # TODO: Initiële data can de coordinator is nog niet beschikbaar op dit punt
+        self.data: dict = elro_connects_api.connector_data[device_id]
 
         self._connector_id = elro_connects_api.connector_id
         self._device_id = device_id

--- a/custom_components/elro_connects/helpers.py
+++ b/custom_components/elro_connects/helpers.py
@@ -1,0 +1,73 @@
+"""Helper functions for Elro Connects."""
+from __future__ import annotations
+
+from elro.device import ATTR_DEVICE_TYPE
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity import EntityDescription
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN, ELRO_CONNECTS_NEW_DEVICE
+from .device import ElroConnectsK1
+
+
+@callback
+def async_set_up_discovery_helper(
+    hass: HomeAssistant,
+    entity_class: type,
+    entry: ConfigEntry,
+    current: set[int],
+    descriptions: dict[str, EntityDescription],
+    async_add_entities: AddEntitiesCallback,
+):
+    """Help to set up an entity."""
+
+    @callback
+    def _async_add_entities():
+        elro_connects_api: ElroConnectsK1 = hass.data[DOMAIN][entry.entry_id]
+        device_data: dict[int, dict] = elro_connects_api.connector_data
+        if not device_data:
+            return
+        new_items = []
+        for device_id, attributes in device_data.items():
+            # description
+            if device_id in current:
+                continue
+            if ATTR_DEVICE_TYPE not in attributes:
+                # Skip a data update if there is no device type attribute provided
+                continue
+            # Ensure we only add entities once
+            current.add(device_id)
+            device_type = attributes[ATTR_DEVICE_TYPE]
+            if device_type in descriptions:
+                new_item = entity_class(
+                    elro_connects_api,
+                    entry,
+                    device_id,
+                    descriptions[device_type],
+                )
+                new_items.append(new_item)
+            else:
+                for attribute in attributes:
+                    if attribute in descriptions:
+                        new_item = entity_class(
+                            elro_connects_api,
+                            entry,
+                            device_id,
+                            descriptions[attribute],
+                        )
+                        new_items.append(new_item)
+
+        async_add_entities(new_items)
+
+    entry.async_on_unload(
+        async_dispatcher_connect(
+            hass,
+            ELRO_CONNECTS_NEW_DEVICE.format(entry.entry_id),
+            _async_add_entities,
+        )
+    )
+    # Initial setup on first fetch
+    _async_add_entities()

--- a/custom_components/elro_connects/sensor.py
+++ b/custom_components/elro_connects/sensor.py
@@ -23,8 +23,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.percentage import ranged_value_to_percentage
 
-from .const import DOMAIN
 from .device import ElroConnectsEntity, ElroConnectsK1
+from .helpers import async_set_up_discovery_helper
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -70,21 +70,15 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the sensor platform."""
-    elro_connects_api: ElroConnectsK1 = hass.data[DOMAIN][config_entry.entry_id]
-    device_status: dict[int, dict] = elro_connects_api.coordinator.data
+    current: set[int] = set()
 
-    async_add_entities(
-        [
-            ElroConnectsSensor(
-                elro_connects_api,
-                config_entry,
-                device_id,
-                SENSOR_TYPES[attribute],
-            )
-            for device_id, attributes in device_status.items()
-            for attribute in attributes
-            if attribute in SENSOR_TYPES
-        ]
+    async_set_up_discovery_helper(
+        hass,
+        ElroConnectsSensor,
+        config_entry,
+        current,
+        SENSOR_TYPES,
+        async_add_entities,
     )
 
 

--- a/custom_components/elro_connects/siren.py
+++ b/custom_components/elro_connects/siren.py
@@ -12,7 +12,6 @@ from elro.device import (
     ALARM_SMOKE,
     ALARM_WATER,
     ATTR_DEVICE_STATE,
-    ATTR_DEVICE_TYPE,
     STATE_SILENCE,
     STATE_TEST_ALARM,
     STATES_OFFLINE,
@@ -25,8 +24,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
 from .device import ElroConnectsEntity, ElroConnectsK1
+from .helpers import async_set_up_discovery_helper
 
 
 @dataclass
@@ -89,20 +88,15 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the sensor platform."""
-    elro_connects_api: ElroConnectsK1 = hass.data[DOMAIN][config_entry.entry_id]
-    device_status: dict[int, dict] = elro_connects_api.coordinator.data
+    current: set[int] = set()
 
-    async_add_entities(
-        [
-            ElroConnectsSiren(
-                elro_connects_api,
-                config_entry,
-                device_id,
-                SIREN_DEVICE_TYPES[attributes[ATTR_DEVICE_TYPE]],
-            )
-            for device_id, attributes in device_status.items()
-            if attributes[ATTR_DEVICE_TYPE] in SIREN_DEVICE_TYPES
-        ]
+    async_set_up_discovery_helper(
+        hass,
+        ElroConnectsSiren,
+        config_entry,
+        current,
+        SIREN_DEVICE_TYPES,
+        async_add_entities,
     )
 
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "Elro Connects",
   "hacs": "1.0.0",
-  "homeassistant": "2022.7.0"
+  "homeassistant": "2022.8.0"
 }

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
 pre-commit
 lib-elro-connects==0.5.3
-homeassistant
+homeassistant==2022.8.0
 pytest-homeassistant-custom-component

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
-coverage==6.4.1
+coverage==6.4.2
 freezegun==1.2.1
 mock-open==1.4.0
 pipdeptree==2.2.1
@@ -8,19 +8,17 @@ pytest-cov==3.0.0
 pytest-freezegun==0.4.2
 pytest-socket==0.5.1
 pytest-test-groups==1.0.3
-pytest-sugar==0.9.4
+pytest-sugar==0.9.5
 pytest-timeout==2.1.0
 pytest-xdist==2.5.0
 pytest==7.1.2
 requests_mock==1.9.2
-respx==0.19.0
+respx==0.19.2
 stdlib-list==0.7.0
 tomli==2.0.1;python_version<"3.11"
-tqdm==4.49.0
-homeassistant==2022.8.0
+tqdm==4.64.0
+homeassistant==2022.8.5
 sqlalchemy==1.4.38
-
-paho-mqtt==1.6.1
 
 fnvhash==0.1.0
 
@@ -28,4 +26,4 @@ lru-dict==1.1.8
 
 lib-elro-connects==0.5.3
 
-pytest-homeassistant-custom-component
+pytest-homeassistant-custom-component==0.11.10

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -24,7 +24,7 @@ paho-mqtt==1.6.1
 
 fnvhash==0.1.0
 
-lru-dict==1.1.7
+lru-dict==1.1.8
 
 lib-elro-connects==0.5.3
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -17,7 +17,7 @@ respx==0.19.0
 stdlib-list==0.7.0
 tomli==2.0.1;python_version<"3.11"
 tqdm==4.49.0
-homeassistant==2022.7.2
+homeassistant==2022.8.0
 sqlalchemy==1.4.38
 
 paho-mqtt==1.6.1

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -180,6 +180,31 @@ async def test_remove_device_from_config_entry(
     assert not await async_remove_config_entry_device(hass, mock_entry, device_entry)
 
 
+async def test_unloading_config_entry(
+    hass: HomeAssistant,
+    mock_k1_connector: dict[AsyncMock],
+    mock_entry: ConfigEntry,
+) -> None:
+    """Test unloading the config entry."""
+    # Initial status holds device info for device [1,2,4]
+    initial_status_data = copy.deepcopy(MOCK_DEVICE_STATUS_DATA)
+    # setup integration with 3 siren entities
+    mock_k1_connector["result"].return_value = initial_status_data
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+    assert hass.states.get("siren.beganegrond") is not None
+    assert hass.states.get("siren.eerste_etage") is not None
+    assert hass.states.get("siren.zolder") is not None
+    assert hass.states.get("siren.beganegrond").state == "off"
+    assert hass.states.get("siren.eerste_etage").state == "on"
+    assert hass.states.get("siren.zolder").state == "off"
+    # Test unload
+    assert await mock_entry.async_unload(hass)
+    assert hass.states.get("siren.beganegrond").state == "unavailable"
+    assert hass.states.get("siren.eerste_etage").state == "unavailable"
+    assert hass.states.get("siren.zolder").state == "unavailable"
+
+
 async def test_update_device_name(
     hass: HomeAssistant,
     mock_k1_connector: dict[AsyncMock],


### PR DESCRIPTION
This PR:
- Refactors the `datacoordinator` by integrating it with the connector update class.
- Removes the custom reloading service
- Refactors setting up new entities, initial and on discovery of a new device, without the need to reload.