### PR TITLE
Bump lib-elro-connects to v0.5.4-1

### DIFF
--- a/custom_components/elro_connects/manifest.json
+++ b/custom_components/elro_connects/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://github.com/jbouwh/ha-elro-connects",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/jbouwh/ha-elro-connects/issues",
-  "requirements": ["lib-elro-connects==0.5.4"],
+  "requirements": ["lib-elro-connects==0.5.4-1"],
   "version": "0.1.13"
 }

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
 pre-commit
-lib-elro-connects==0.5.4
+lib-elro-connects==0.5.4-1
 homeassistant==2022.8.0
 pytest-homeassistant-custom-component

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -24,6 +24,6 @@ fnvhash==0.1.0
 
 lru-dict==1.1.8
 
-lib-elro-connects==0.5.4
+lib-elro-connects==0.5.4-1
 
 pytest-homeassistant-custom-component==0.11.10


### PR DESCRIPTION
Bump lib-elro-connects to v0.5.4-1
Fix some condition where HA cannot connect to the K1 connector.